### PR TITLE
Reject duplicate Dokka module names

### DIFF
--- a/dokka/private/multi_module.bzl
+++ b/dokka/private/multi_module.bzl
@@ -29,6 +29,7 @@ def _validate_module_path(module_path, label):
 
 def _dokka_multi_module_impl(ctx):
     modules = []
+    module_names = {}
     module_paths = {}
     module_outputs = []
     module_includes = []
@@ -42,6 +43,17 @@ def _dokka_multi_module_impl(ctx):
                     module.format,
                 ),
             )
+
+        module_name = module.module_name
+        if module_name in module_names:
+            fail(
+                "Dokka targets {} and {} both resolve to module name '{}'; set unique module_name values.".format(
+                    module_names[module_name],
+                    target.label,
+                    module_name,
+                ),
+            )
+        module_names[module_name] = target.label
 
         module_path = module.module_path
         _validate_module_path(module_path, target.label)
@@ -62,7 +74,7 @@ def _dokka_multi_module_impl(ctx):
         # that version-matched contract end to end.
         modules.append({
             "includes": [include.path for include in includes],
-            "name": module.module_name,
+            "name": module_name,
             "relativePathToOutputDirectory": module_path,
             "sourceOutputDirectory": module.partial_documentation.path,
         })

--- a/tests/rules/BUILD.bazel
+++ b/tests/rules/BUILD.bazel
@@ -86,6 +86,12 @@ dokka(
 )
 
 dokka(
+    name = "docs",
+    srcs = ["Fixture.kt"],
+    tags = ["manual"],
+)
+
+dokka(
     name = "module_api_fixture",
     srcs = ["Fixture.kt"],
     includes = ["module.md"],
@@ -125,6 +131,15 @@ dokka_multi_module(
     modules = [
         ":module_api_fixture",
         ":duplicate_module_path_fixture",
+    ],
+    tags = ["manual"],
+)
+
+dokka_multi_module(
+    name = "duplicate_module_name_aggregate_fixture",
+    modules = [
+        "//tests/rules/nested:docs",
+        ":docs",
     ],
     tags = ["manual"],
 )

--- a/tests/rules/dokka_analysis_test.bzl
+++ b/tests/rules/dokka_analysis_test.bzl
@@ -379,6 +379,11 @@ def _duplicate_module_path_test_impl(ctx):
     asserts.expect_failure(env, "both resolve to module path 'api'")
     return analysistest.end(env)
 
+def _duplicate_module_name_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    asserts.expect_failure(env, "both resolve to module name 'docs'")
+    return analysistest.end(env)
+
 def _invalid_module_path_test_impl(ctx):
     env = analysistest.begin(ctx)
     asserts.expect_failure(env, "has invalid module_path '../invalid'")
@@ -399,6 +404,10 @@ _invalid_config_test = analysistest.make(
 )
 _duplicate_module_path_test = analysistest.make(
     _duplicate_module_path_test_impl,
+    expect_failure = True,
+)
+_duplicate_module_name_test = analysistest.make(
+    _duplicate_module_name_test_impl,
     expect_failure = True,
 )
 _invalid_module_path_test = analysistest.make(
@@ -440,6 +449,10 @@ def dokka_analysis_test_suite(name):
         name = name + "_duplicate_module_path",
         target_under_test = ":duplicate_aggregate_fixture",
     )
+    _duplicate_module_name_test(
+        name = name + "_duplicate_module_name",
+        target_under_test = ":duplicate_module_name_aggregate_fixture",
+    )
     _invalid_module_path_test(
         name = name + "_invalid_module_path",
         target_under_test = ":invalid_path_aggregate_fixture",
@@ -453,6 +466,7 @@ def dokka_analysis_test_suite(name):
         tests = [
             ":" + name + "_configuration",
             ":" + name + "_defaults",
+            ":" + name + "_duplicate_module_name",
             ":" + name + "_duplicate_module_path",
             ":" + name + "_invalid_config",
             ":" + name + "_invalid_module_path",


### PR DESCRIPTION
Fail early when aggregated modules resolve to the same Dokka module name, preventing modules from being omitted or linked incorrectly.