### PR TITLE
Remove ineffective aggregate Dokka settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,11 @@ portable relative paths and unique within an aggregate. Only HTML `dokka`
 targets can be aggregated.
 
 The aggregate rule uses the same precedence and consumes the selected
-configuration's publication settings:
-`fail_on_warning`, `offline_mode`, `plugins`, `plugins_configuration`,
-`suppress_inherited_members`, and `suppress_obvious_functions`. Source-analysis
-settings in the same configuration continue to apply only to `dokka` targets.
-Root-level Markdown remains target-specific through `includes`.
+configuration's `offline_mode`, `plugins`, and `plugins_configuration` settings.
+Source-generation settings such as `fail_on_warning`,
+`suppress_inherited_members`, and `suppress_obvious_functions` apply to the
+individual `dokka` module targets instead. Root-level Markdown remains
+target-specific through `includes`.
 
 ### Common options
 

--- a/dokka/private/DokkaGeneratorRunner.java
+++ b/dokka/private/DokkaGeneratorRunner.java
@@ -122,6 +122,7 @@ public final class DokkaGeneratorRunner {
       }
     }
 
+    // AllModulesPageGeneration ignores the single-module warning and suppression settings.
     return new DokkaConfigurationImpl(
         requiredText(root, "moduleName"),
         optionalText(root, "moduleVersion"),
@@ -132,11 +133,11 @@ public final class DokkaGeneratorRunner {
         new ArrayList<>(files(root.path("pluginsClasspath"))),
         pluginConfigurations,
         modules,
-        root.path("failOnWarning").asBoolean(),
         false,
-        root.path("suppressObviousFunctions").asBoolean(true),
+        false,
+        true,
         files(root.path("includes")),
-        root.path("suppressInheritedMembers").asBoolean(),
+        false,
         root.path("finalizeCoroutines").asBoolean(true));
   }
 

--- a/dokka/private/multi_module.bzl
+++ b/dokka/private/multi_module.bzl
@@ -94,7 +94,6 @@ def _dokka_multi_module_impl(ctx):
         output = configuration,
         content = json.encode({
             "delayTemplateSubstitution": False,
-            "failOnWarning": settings.fail_on_warning,
             "finalizeCoroutines": True,
             "includes": [include.path for include in ctx.files.includes],
             "moduleName": ctx.attr.title or ctx.label.name,
@@ -115,8 +114,6 @@ def _dokka_multi_module_impl(ctx):
             ],
             "runnerMode": "rules_dokka_multi_module",
             "sourceSets": [],
-            "suppressInheritedMembers": settings.suppress_inherited_members,
-            "suppressObviousFunctions": settings.suppress_obvious_functions,
         }),
     )
 

--- a/tests/rules/dokka_analysis_test.bzl
+++ b/tests/rules/dokka_analysis_test.bzl
@@ -225,10 +225,10 @@ def _dokka_multi_module_test_impl(ctx):
         asserts.equals(env, "rules_dokka_multi_module", configuration["runnerMode"])
         asserts.equals(env, False, configuration["delayTemplateSubstitution"])
         asserts.equals(env, True, configuration["finalizeCoroutines"])
-        asserts.equals(env, True, configuration["failOnWarning"])
         asserts.equals(env, False, configuration["offlineMode"])
-        asserts.equals(env, False, configuration["suppressObviousFunctions"])
-        asserts.equals(env, True, configuration["suppressInheritedMembers"])
+        asserts.false(env, "failOnWarning" in configuration)
+        asserts.false(env, "suppressInheritedMembers" in configuration)
+        asserts.false(env, "suppressObviousFunctions" in configuration)
         asserts.equals(env, [], configuration["sourceSets"])
         asserts.equals(
             env,


### PR DESCRIPTION
Remove aggregate-level Dokka settings that have no effect in Dokka 2.2 multi-module generation.

`fail_on_warning`, `suppress_inherited_members`, and `suppress_obvious_functions` now remain explicitly scoped to individual `dokka` module targets, where Dokka actually consumes them. The aggregate manifest and README now document only the settings the aggregate uses.