### PR TITLE
Support Kotlin Wasm analysis in Dokka

### DIFF
--- a/dokka/private/config.bzl
+++ b/dokka/private/config.bzl
@@ -17,7 +17,7 @@ def _dokka_config_attrs():
         "analysis_platform": attr.string(
             default = "jvm",
             doc = "Platform used for source analysis.",
-            values = ["common", "js", "jvm", "native"],
+            values = ["common", "js", "jvm", "native", "wasm"],
         ),
         "api_version": attr.string(
             doc = "Kotlin API version used for source analysis.",

--- a/tests/rules/BUILD.bazel
+++ b/tests/rules/BUILD.bazel
@@ -65,6 +65,12 @@ dokka_config(
     suppress_obvious_functions = False,
 )
 
+dokka_config(
+    name = "wasm_config",
+    analysis_platform = "wasm",
+    tags = ["manual"],
+)
+
 dokka(
     name = "analysis_fixture",
     srcs = ["Fixture.kt"],
@@ -77,6 +83,13 @@ dokka(
     suppressed_files = ["Suppressed.kt"],
     tags = ["manual"],
     deps = [":dependency"],
+)
+
+dokka(
+    name = "wasm_fixture",
+    srcs = ["Fixture.kt"],
+    config = ":wasm_config",
+    tags = ["manual"],
 )
 
 dokka(

--- a/tests/rules/dokka_analysis_test.bzl
+++ b/tests/rules/dokka_analysis_test.bzl
@@ -200,6 +200,22 @@ def _dokka_defaults_test_impl(ctx):
 
     return analysistest.end(env)
 
+def _dokka_wasm_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    write_actions = _actions_with_mnemonic(env, "FileWrite")
+    asserts.equals(env, 2, len(write_actions))
+
+    normal_write = _write_action_for_output(env, "wasm_fixture.dokka.json")
+    if normal_write:
+        configuration = json.decode(normal_write.content)
+        asserts.equals(
+            env,
+            "wasm",
+            configuration["sourceSets"][0]["analysisPlatform"],
+        )
+
+    return analysistest.end(env)
+
 def _dokka_multi_module_test_impl(ctx):
     env = analysistest.begin(ctx)
     target = analysistest.target_under_test(env)
@@ -391,6 +407,7 @@ def _non_html_module_test_impl(ctx):
 
 _dokka_configuration_test = analysistest.make(_dokka_configuration_test_impl)
 _dokka_defaults_test = analysistest.make(_dokka_defaults_test_impl)
+_dokka_wasm_test = analysistest.make(_dokka_wasm_test_impl)
 _dokka_multi_module_test = analysistest.make(_dokka_multi_module_test_impl)
 _dokka_reusable_config_test = analysistest.make(_dokka_reusable_config_test_impl)
 _invalid_config_test = analysistest.make(
@@ -423,6 +440,10 @@ def dokka_analysis_test_suite(name):
     _dokka_defaults_test(
         name = name + "_defaults",
         target_under_test = ":defaults_fixture",
+    )
+    _dokka_wasm_test(
+        name = name + "_wasm",
+        target_under_test = ":wasm_fixture",
     )
     _dokka_multi_module_test(
         name = name + "_multi_module",
@@ -459,5 +480,6 @@ def dokka_analysis_test_suite(name):
             ":" + name + "_multi_module",
             ":" + name + "_non_html_module",
             ":" + name + "_reusable_config",
+            ":" + name + "_wasm",
         ],
     )


### PR DESCRIPTION
Add `wasm` as a supported `analysis_platform` value so Kotlin/Wasm sources can be analyzed with Dokka 2.2, matching Dokka’s supported platform enum.