### PR TITLE
Rename bazel_rules_dokka -> rules_dokka

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,12 +1,12 @@
 {
-  "homepage": "https://github.com/Bencodes/bazel_rules_dokka",
+  "homepage": "https://github.com/Bencodes/rules_dokka",
   "maintainers": [
     {
       "github": "Bencodes"
     }
   ],
   "repository": [
-    "github:Bencodes/bazel_rules_dokka"
+    "github:Bencodes/rules_dokka"
   ],
   "versions": [],
   "yanked_versions": {}

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "**leave this alone**",
-  "strip_prefix": "bazel_rules_dokka-{VERSION}",
-  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/bazel_rules_dokka-{TAG}.tar.gz"
+  "strip_prefix": "rules_dokka-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_dokka-{TAG}.tar.gz"
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bazel_rules_dokka
+# rules_dokka
 
 Bzlmod-first Bazel rules for generating Kotlin and Java API documentation with
 [Dokka](https://kotlinlang.org/docs/dokka-introduction.html).


### PR DESCRIPTION
Renaming the repo from bazel_rules_dokka to rules_dokka